### PR TITLE
Fix Turbo Frame navigation in new person form

### DIFF
--- a/rails-app/app/views/people/new.html.erb
+++ b/rails-app/app/views/people/new.html.erb
@@ -1,5 +1,5 @@
 <div class="max-w-2xl mx-auto p-4 md:p-6">
-  <%= turbo_frame_tag "new_person" do %>
+  <%= turbo_frame_tag "new_person", target: "_top" do %>
     <h1 class="text-2xl md:text-3xl font-bold text-gray-900 mb-6">New PII Record</h1>
 
     <%= form_with model: @person, class: "space-y-6" do |form| %>


### PR DESCRIPTION
- Add target: '_top' to turbo_frame_tag in new.html.erb
- Fixes 'Content missing' error when creating new PII records
- Ensures proper page navigation after successful form submission
- Consistent with edit.html.erb Turbo Frame implementation